### PR TITLE
fix(timeout): increasing port search timeout

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -72,7 +72,7 @@ void MainWindow::setupComSettings()
     connect(ui->ComOpenButton, &QPushButton::clicked, this, &MainWindow::onConnectButtonClicked);
     port_search_timer_ = new QTimer(this);
     connect(port_search_timer_, &QTimer::timeout, this, &MainWindow::onPortSearchTimerTimeout);
-    port_search_timer_->start(500);
+    port_search_timer_->start(5000);
 }
 
 void MainWindow::setupServoLists()


### PR DESCRIPTION
Hello there !

Here's a small PR increasing the timeout value of `port_search_timer_` to 5 seconds instead of 0.5 seconds. 
In the current version, the 0.5 seconds timeout is almost instantaneously reached when selecting a port in the drop-down list. As a result, the selected port keeps reseting to its default value `debug-console`, and makes it almost impossible to open another port than the default one.
In the new version, the 5 seconds timeout is quite enough to select the desired port and open it :) 

Thanks for providing such a nice tool for Unix users to debug Feetech servos !

Best,

Caroline.