### PR TITLE
Update README with binary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ Utility for Feetech SCS/STS servo
 ```
 wget https://github.com/Kotakku/FT_SCServo_Debug_Qt/releases/download/v1.1.0/ft-scservo-debug-qt_1.1.0_amd64.deb
 sudo apt install ./ft-scservo-debug-qt_1.1.0_amd64.deb
+FT_SCServo_Debug_Qt
 ```
 
 ### arm64
 ```
 wget https://github.com/Kotakku/FT_SCServo_Debug_Qt/releases/download/v1.1.0/ft-scservo-debug-qt_1.1.0_arm64.deb
 sudo apt install ./ft-scservo-debug-qt_1.1.0_arm64.deb
+FT_SCServo_Debug_Qt
 ```
 
 ## Build with Qt


### PR DESCRIPTION
Added to the installation instructions for FT_SCServo_Debug_Qt for amd64 and arm64 what the name of the binary is.